### PR TITLE
feat(admin): configure Django Jazzmin admin for custom user management

### DIFF
--- a/service/cabulous/settings.py
+++ b/service/cabulous/settings.py
@@ -150,6 +150,7 @@ JAZZMIN_SETTINGS = {
     "search_model": ["users.User"],
     "show_sidebar": True,
     "navigation_expanded": True,
+    "changeform_format": "horizontal_tabs",
     "hide_apps": [],
     "hide_models": [],
     "order_with_respect_to": ["auth", "monitoring"],

--- a/service/users/admin.py
+++ b/service/users/admin.py
@@ -1,3 +1,113 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
 
-# Register your models here.
+from users.models import User, UserMagicLinkToken
+
+
+@admin.register(User)
+class CustomUserAdmin(UserAdmin):
+    model = User
+
+    list_display = (
+        "username",
+        "email",
+        "first_name",
+        "last_name",
+        "is_active",
+        "is_staff",
+        "invited_at",
+        "invitation_accepted_at",
+        "password_defined_at",
+        "onboarding_completed_at",
+    )
+    search_fields = (
+        "username",
+        "email",
+        "first_name",
+        "last_name",
+        "discord_username",
+        "phone_number",
+    )
+    list_filter = (
+        "is_active",
+        "is_staff",
+        "is_superuser",
+        "groups",
+        ("invited_at", admin.EmptyFieldListFilter),
+        ("invitation_accepted_at", admin.EmptyFieldListFilter),
+        ("password_defined_at", admin.EmptyFieldListFilter),
+        ("onboarding_completed_at", admin.EmptyFieldListFilter),
+    )
+    ordering = ("username",)
+    filter_horizontal = ("groups", "user_permissions")
+    readonly_fields = ("created_at", "updated_at", "date_joined", "last_login")
+
+    fieldsets = (
+        (None, {"fields": ("username", "password")}),
+        ("Informações Pessoais", {"fields": ("first_name", "last_name", "email")}),
+        (
+            "Perfil",
+            {
+                "fields": (
+                    "discord_username",
+                    "phone_number",
+                    "bio",
+                    "avatar",
+                    "banner",
+                )
+            },
+        ),
+        (
+            "Jornada",
+            {
+                "fields": (
+                    "invited_at",
+                    "invitation_accepted_at",
+                    "password_defined_at",
+                    "onboarding_completed_at",
+                )
+            },
+        ),
+        (
+            "Permissões",
+            {"fields": ("is_active", "is_staff", "is_superuser", "groups", "user_permissions")},
+        ),
+        (
+            "Datas Importantes",
+            {"fields": ("last_login", "date_joined", "created_at", "updated_at")},
+        ),
+    )
+
+    add_fieldsets = (
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": (
+                    "username",
+                    "email",
+                    "first_name",
+                    "last_name",
+                    "password1",
+                    "password2",
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                    "groups",
+                    "user_permissions",
+                ),
+            },
+        ),
+    )
+
+
+@admin.register(UserMagicLinkToken)
+class UserMagicLinkTokenAdmin(admin.ModelAdmin):
+    list_display = ("user", "created_by", "expires_at", "used_at", "created_at")
+    search_fields = ("user__username", "user__email", "token")
+    list_filter = (
+        ("used_at", admin.EmptyFieldListFilter),
+        ("expires_at", admin.DateFieldListFilter),
+        ("created_at", admin.DateFieldListFilter),
+    )
+    readonly_fields = ("token", "created_at", "updated_at")


### PR DESCRIPTION
## Descrição
Configura o Django Admin (Jazzmin) para gerenciamento completo do `Custom User`, com foco em operação administrativa interna, suporte e manutenção de dados.  
Foram organizados campos, filtros, busca e permissões no `CustomUserAdmin`, além de ajustes de layout no Jazzmin para melhorar a usabilidade do painel.

## Issue relacionada
Closes #33

## Tipo de mudança
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore
- [ ] Docs

## O que foi alterado
- Registrado `users.User` com `CustomUserAdmin`, incluindo `list_display`, `search_fields`, `list_filter`, `fieldsets`, `add_fieldsets` e suporte a grupos/permissões.
- Configurado Jazzmin para visualização em abas (`horizontal_tabs`) no formulário de edição, melhorando navegação e organização dos campos administrativos.