### PR TITLE
feat(auth): add first-access onboarding completion endpoint

### DIFF
--- a/service/authentication/serializers.py
+++ b/service/authentication/serializers.py
@@ -1,12 +1,17 @@
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from django.contrib.auth import authenticate, get_user_model
+from django.contrib.auth.password_validation import validate_password
+from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
 
 User = get_user_model()
+
+if TYPE_CHECKING:
+    from users.models import User as UserType
 
 
 class LoginSerializer(serializers.Serializer):
@@ -69,3 +74,50 @@ class MeSerializer(serializers.ModelSerializer):
 
 class RefreshTokenSerializer(TokenRefreshSerializer):
     pass
+
+
+class OnboardingFirstAccessSerializer(serializers.ModelSerializer):
+    new_password = serializers.CharField(write_only=True, trim_whitespace=False)
+
+    class Meta:
+        model = User
+        fields = (
+            "new_password",
+            "email",
+            "username",
+            "first_name",
+            "last_name",
+            "discord_username",
+            "phone_number",
+            "avatar",
+            "bio",
+        )
+
+    def validate_new_password(self, value: str) -> str:
+        user = self.instance
+        validate_password(value, user=user)
+        return value
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if "new_password" not in attrs:
+            raise serializers.ValidationError({"new_password": "This field is required."})
+        return attrs
+
+    def update(self, instance: "UserType", validated_data: dict[str, Any]) -> "UserType":
+        password = validated_data.pop("new_password", None)
+        if password is None:
+            raise serializers.ValidationError({"new_password": "This field is required."})
+
+        for field, value in validated_data.items():
+            setattr(instance, field, value)
+
+        instance.set_password(password)
+
+        now = timezone.now()
+        instance.password_defined_at = now
+        instance.onboarding_completed_at = now
+        if instance.invitation_accepted_at is None:
+            instance.invitation_accepted_at = now
+
+        instance.save()
+        return instance

--- a/service/authentication/urls.py
+++ b/service/authentication/urls.py
@@ -1,10 +1,21 @@
 from django.urls import path
 
-from authentication.views import LoginView, LogoutView, MeView, RefreshView
+from authentication.views import (
+    LoginView,
+    LogoutView,
+    MeView,
+    OnboardingFirstAccessView,
+    RefreshView,
+)
 
 urlpatterns = [
     path("login/", LoginView.as_view(), name="auth-login"),
     path("refresh/", RefreshView.as_view(), name="auth-refresh"),
     path("logout/", LogoutView.as_view(), name="auth-logout"),
     path("me/", MeView.as_view(), name="auth-me"),
+    path(
+        "onboarding/complete/",
+        OnboardingFirstAccessView.as_view(),
+        name="auth-onboarding-complete",
+    ),
 ]

--- a/service/authentication/views.py
+++ b/service/authentication/views.py
@@ -11,6 +11,7 @@ from authentication.serializers import (
     LoginSerializer,
     LogoutSerializer,
     MeSerializer,
+    OnboardingFirstAccessSerializer,
     RefreshTokenSerializer,
 )
 
@@ -65,3 +66,23 @@ class MeView(APIView):
     def get(self, request, *_args, **_kwargs):
         serializer = MeSerializer(request.user, context={"request": request})
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class OnboardingFirstAccessView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *_args, **_kwargs):
+        user = request.user
+        if user.onboarding_completed_at is not None:
+            return Response(
+                {"detail": "Onboarding has already been completed."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer = OnboardingFirstAccessSerializer(instance=user, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+        return Response(
+            MeSerializer(user, context={"request": request}).data,
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
## Descrição
Implementado o endpoint de conclusão de onboarding de primeiro acesso no app `authentication`, permitindo que o usuário autenticado defina a nova senha e atualize dados básicos de perfil no mesmo fluxo.

O endpoint valida força de senha com as regras do Django, atualiza os campos de status do onboarding e retorna os dados atuais do usuário autenticado.

## Issue relacionada
Closes #34

## Tipo de mudança
- [x] Feature
- [x] Fix
- [ ] Refactor
- [ ] Chore
- [ ] Docs

## O que foi alterado
- Adicionado endpoint `POST /api/auth/onboarding/complete/` no app `authentication`.
- Criado serializer de onboarding para definir `new_password` e atualizar campos de perfil (`email`, `username`, `first_name`, `last_name`, `discord_username`, `phone_number`, `avatar`, `bio`).
- Atualização de estado no onboarding: `password_defined_at`, `onboarding_completed_at` e `invitation_accepted_at` (quando aplicável), com validação obrigatória de `new_password`.