### PR TITLE
feat(users): add username validation, normalization and case-insensitive uniqueness

### DIFF
--- a/service/authentication/serializers.py
+++ b/service/authentication/serializers.py
@@ -1,12 +1,14 @@
 from typing import TYPE_CHECKING, Any, cast
 
 from django.contrib.auth import authenticate, get_user_model
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.contrib.auth.password_validation import validate_password
 from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
+from users.validators import clean_username, normalize_username
 
 User = get_user_model()
 
@@ -22,7 +24,7 @@ class LoginSerializer(serializers.Serializer):
         identifier = attrs["identifier"]
         password = attrs["password"]
 
-        user = authenticate(username=identifier, password=password)
+        user = authenticate(username=normalize_username(identifier), password=password)
         if user is None:
             user_from_email = User.objects.filter(email__iexact=identifier).first()
             if user_from_email is not None:
@@ -92,6 +94,9 @@ class OnboardingFirstAccessSerializer(serializers.ModelSerializer):
             "avatar",
             "bio",
         )
+        extra_kwargs = {
+            "username": {"validators": []},
+        }
 
     def validate_new_password(self, value: str) -> str:
         user = self.instance
@@ -102,6 +107,13 @@ class OnboardingFirstAccessSerializer(serializers.ModelSerializer):
         if "new_password" not in attrs:
             raise serializers.ValidationError({"new_password": "This field is required."})
         return attrs
+
+    def validate_username(self, value: str) -> str:
+        instance_pk = self.instance.pk if self.instance is not None else None
+        try:
+            return clean_username(value, queryset=User.objects.all(), exclude_pk=instance_pk)
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.messages)
 
     def update(self, instance: "UserType", validated_data: dict[str, Any]) -> "UserType":
         password = validated_data.pop("new_password", None)

--- a/service/authentication/serializers.py
+++ b/service/authentication/serializers.py
@@ -8,7 +8,12 @@ from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
-from users.validators import clean_username, normalize_username
+from users.validators import (
+    clean_discord_username,
+    clean_phone_number,
+    clean_username,
+    normalize_username,
+)
 
 User = get_user_model()
 
@@ -112,6 +117,18 @@ class OnboardingFirstAccessSerializer(serializers.ModelSerializer):
         instance_pk = self.instance.pk if self.instance is not None else None
         try:
             return clean_username(value, queryset=User.objects.all(), exclude_pk=instance_pk)
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.messages)
+
+    def validate_discord_username(self, value: str) -> str:
+        try:
+            return clean_discord_username(value)
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.messages)
+
+    def validate_phone_number(self, value: str) -> str:
+        try:
+            return clean_phone_number(value)
         except DjangoValidationError as exc:
             raise serializers.ValidationError(exc.messages)
 

--- a/service/pyproject.toml
+++ b/service/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "djangorestframework>=3.16.1",
     "flower>=2.0.1",
     "gunicorn>=25.1.0",
+    "phonenumbers>=9.0.17",
     "pillow>=12.1.1",
     "psycopg[binary]>=3.3.3",
     "pydantic-settings>=2.13.1",

--- a/service/users/models.py
+++ b/service/users/models.py
@@ -3,8 +3,10 @@ from pathlib import Path
 
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+from django.db.models.functions import Lower
 
 from common.models.abstracts import BaseModel
+from users.validators import normalize_username, validate_username_format
 
 
 def user_media_base_path(instance: models.Model) -> str:
@@ -23,6 +25,12 @@ def user_banner_upload_to(instance: models.Model, filename: str) -> str:
 
 
 class User(BaseModel, AbstractUser):
+    username = models.CharField(
+        verbose_name="Nome de usuário",
+        max_length=150,
+        unique=True,
+        validators=[validate_username_format],
+    )
     email = models.EmailField(
         verbose_name="E-mail",
         unique=True,
@@ -86,6 +94,9 @@ class User(BaseModel, AbstractUser):
             models.Index(fields=["discord_username"], name="users_discord_idx"),
             models.Index(fields=["phone_number"], name="users_phone_idx"),
         ]
+        constraints = [
+            models.UniqueConstraint(Lower("username"), name="users_username_ci_unique"),
+        ]
 
     @property
     def full_name(self) -> str:
@@ -93,6 +104,10 @@ class User(BaseModel, AbstractUser):
 
     def __str__(self) -> str:
         return self.username
+
+    def save(self, *args, **kwargs):
+        self.username = normalize_username(self.username)
+        return super().save(*args, **kwargs)
 
 
 class UserMagicLinkToken(BaseModel):

--- a/service/users/models.py
+++ b/service/users/models.py
@@ -6,7 +6,14 @@ from django.db import models
 from django.db.models.functions import Lower
 
 from common.models.abstracts import BaseModel
-from users.validators import normalize_username, validate_username_format
+from users.validators import (
+    normalize_discord_username,
+    normalize_phone_number,
+    normalize_username,
+    validate_discord_username_format,
+    validate_phone_number_format,
+    validate_username_format,
+)
 
 
 def user_media_base_path(instance: models.Model) -> str:
@@ -41,12 +48,14 @@ class User(BaseModel, AbstractUser):
         max_length=100,
         blank=True,
         default="",
+        validators=[validate_discord_username_format],
     )
     phone_number = models.CharField(
         verbose_name="Número de telefone",
         max_length=20,
         blank=True,
         default="",
+        validators=[validate_phone_number_format],
     )
     avatar = models.ImageField(
         verbose_name="Avatar",
@@ -89,7 +98,6 @@ class User(BaseModel, AbstractUser):
     class Meta(BaseModel.Meta):
         verbose_name = "Usuário"
         verbose_name_plural = "Usuários"
-
         indexes = [
             models.Index(fields=["discord_username"], name="users_discord_idx"),
             models.Index(fields=["phone_number"], name="users_phone_idx"),
@@ -107,6 +115,8 @@ class User(BaseModel, AbstractUser):
 
     def save(self, *args, **kwargs):
         self.username = normalize_username(self.username)
+        self.discord_username = normalize_discord_username(self.discord_username)
+        self.phone_number = normalize_phone_number(self.phone_number)
         return super().save(*args, **kwargs)
 
 

--- a/service/users/serializers.py
+++ b/service/users/serializers.py
@@ -9,7 +9,7 @@ from rest_framework.exceptions import PermissionDenied
 
 from cabulous.config import get_settings
 from users.models import User, UserMagicLinkToken
-from users.validators import clean_username
+from users.validators import clean_discord_username, clean_phone_number, clean_username
 
 SELF_EDITABLE_FIELDS = {
     "username",
@@ -103,6 +103,18 @@ class UserSerializer(serializers.ModelSerializer):
         instance_pk = self.instance.pk if self.instance is not None else None
         try:
             return clean_username(value, queryset=User.objects.all(), exclude_pk=instance_pk)
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.messages)
+
+    def validate_discord_username(self, value: str) -> str:
+        try:
+            return clean_discord_username(value)
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.messages)
+
+    def validate_phone_number(self, value: str) -> str:
+        try:
+            return clean_phone_number(value)
         except DjangoValidationError as exc:
             raise serializers.ValidationError(exc.messages)
 

--- a/service/users/serializers.py
+++ b/service/users/serializers.py
@@ -2,12 +2,14 @@ import secrets
 import string
 from datetime import timedelta
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 
 from cabulous.config import get_settings
 from users.models import User, UserMagicLinkToken
+from users.validators import clean_username
 
 SELF_EDITABLE_FIELDS = {
     "username",
@@ -69,6 +71,9 @@ class UserSerializer(serializers.ModelSerializer):
             "magic_link",
             "magic_link_expires_at",
         )
+        extra_kwargs = {
+            "username": {"validators": []},
+        }
 
     def validate(self, attrs: dict) -> dict:
         request = self.context.get("request")
@@ -93,6 +98,13 @@ class UserSerializer(serializers.ModelSerializer):
                 )
 
         return attrs
+
+    def validate_username(self, value: str) -> str:
+        instance_pk = self.instance.pk if self.instance is not None else None
+        try:
+            return clean_username(value, queryset=User.objects.all(), exclude_pk=instance_pk)
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.messages)
 
     def create(self, validated_data: dict) -> User:
         request = self.context.get("request")

--- a/service/users/validators.py
+++ b/service/users/validators.py
@@ -7,8 +7,8 @@ from django.db.models import QuerySet
 from phonenumbers import NumberParseException
 from phonenumbers.phonenumberutil import PhoneNumberFormat
 
-USERNAME_PATTERN = re.compile(r"^[a-z0-9_.-]+$")
-DISCORD_USERNAME_PATTERN = re.compile(r"^[a-z0-9._]+$")
+USERNAME_PATTERN = re.compile(r"^(?=.{3,30}$)[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$")
+DISCORD_USERNAME_PATTERN = re.compile(r"^(?=.{2,32}$)(?!(?:everyone|here)$)[a-z0-9._]+$")
 DEFAULT_PHONE_REGION = "BR"
 
 

--- a/service/users/validators.py
+++ b/service/users/validators.py
@@ -1,0 +1,48 @@
+import re
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.db.models import QuerySet
+
+USERNAME_PATTERN = re.compile(r"^[a-z0-9_.-]+$")
+
+
+def normalize_username(value: str) -> str:
+    return value.strip().lower()
+
+
+def validate_username_format(value: str) -> None:
+    if not value:
+        raise ValidationError("Username is required.")
+    if " " in value:
+        raise ValidationError("Username cannot contain spaces.")
+    if not USERNAME_PATTERN.fullmatch(value):
+        raise ValidationError(
+            "Username can only contain lowercase letters, numbers, dots, underscores, and hyphens."
+        )
+
+
+def ensure_username_available(
+    queryset: QuerySet,
+    username: str,
+    *,
+    exclude_pk: Any = None,
+) -> None:
+    candidates = queryset.filter(username__iexact=username)
+    if exclude_pk is not None:
+        candidates = candidates.exclude(pk=exclude_pk)
+    if candidates.exists():
+        raise ValidationError("This username is already in use.")
+
+
+def clean_username(
+    value: str,
+    *,
+    queryset: QuerySet | None = None,
+    exclude_pk: Any = None,
+) -> str:
+    normalized = normalize_username(value)
+    validate_username_format(normalized)
+    if queryset is not None:
+        ensure_username_available(queryset, normalized, exclude_pk=exclude_pk)
+    return normalized

--- a/service/users/validators.py
+++ b/service/users/validators.py
@@ -1,10 +1,15 @@
 import re
 from typing import Any
 
+import phonenumbers
 from django.core.exceptions import ValidationError
 from django.db.models import QuerySet
+from phonenumbers import NumberParseException
+from phonenumbers.phonenumberutil import PhoneNumberFormat
 
 USERNAME_PATTERN = re.compile(r"^[a-z0-9_.-]+$")
+DISCORD_USERNAME_PATTERN = re.compile(r"^[a-z0-9._]+$")
+DEFAULT_PHONE_REGION = "BR"
 
 
 def normalize_username(value: str) -> str:
@@ -45,4 +50,56 @@ def clean_username(
     validate_username_format(normalized)
     if queryset is not None:
         ensure_username_available(queryset, normalized, exclude_pk=exclude_pk)
+    return normalized
+
+
+def normalize_discord_username(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized.startswith("@"):
+        normalized = normalized[1:]
+    return normalized
+
+
+def validate_discord_username_format(value: str) -> None:
+    if not value:
+        return
+    if " " in value:
+        raise ValidationError("Discord username cannot contain spaces.")
+    if not DISCORD_USERNAME_PATTERN.fullmatch(value):
+        raise ValidationError(
+            "Discord username can only contain lowercase letters, numbers, dots, and underscores."
+        )
+
+
+def clean_discord_username(value: str) -> str:
+    normalized = normalize_discord_username(value)
+    validate_discord_username_format(normalized)
+    return normalized
+
+
+def normalize_phone_number(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        return ""
+    try:
+        parsed = phonenumbers.parse(normalized, DEFAULT_PHONE_REGION)
+    except NumberParseException:
+        return normalized
+    return phonenumbers.format_number(parsed, PhoneNumberFormat.E164)
+
+
+def validate_phone_number_format(value: str) -> None:
+    if not value:
+        return
+    try:
+        parsed = phonenumbers.parse(value, DEFAULT_PHONE_REGION)
+    except NumberParseException as exc:
+        raise ValidationError("Invalid phone number.") from exc
+    if not phonenumbers.is_valid_number(parsed):
+        raise ValidationError("Invalid phone number.")
+
+
+def clean_phone_number(value: str) -> str:
+    normalized = normalize_phone_number(value)
+    validate_phone_number_format(normalized)
     return normalized

--- a/service/uv.lock
+++ b/service/uv.lock
@@ -95,6 +95,7 @@ dependencies = [
     { name = "djangorestframework-simplejwt" },
     { name = "flower" },
     { name = "gunicorn" },
+    { name = "phonenumbers" },
     { name = "pillow" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
@@ -118,6 +119,7 @@ requires-dist = [
     { name = "djangorestframework-simplejwt", specifier = ">=5.5.1" },
     { name = "flower", specifier = ">=2.0.1" },
     { name = "gunicorn", specifier = ">=25.1.0" },
+    { name = "phonenumbers", specifier = ">=9.0.17" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
@@ -431,6 +433,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "phonenumbers"
+version = "9.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/a3/3720326431a23c8e8944a07cdf51520608f1fded87e32e991116fdb801bd/phonenumbers-9.0.26.tar.gz", hash = "sha256:9e582c827f0f5503cddeebef80099475a52ffa761551d8384099c7ec71298cbf", size = 2298587, upload-time = "2026-03-13T11:34:19.656Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/93/8825b3c9c23e595f34aa11735b29550c27a0f57fe4fc8c9ee737390566ca/phonenumbers-9.0.26-py2.py3-none-any.whl", hash = "sha256:ff473da5712965b6c7f7a31cbff8255864df694eb48243771133ecb761e807c1", size = 2584969, upload-time = "2026-03-13T11:34:16.671Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Descrição
Implementada a camada central de validação e normalização de identificadores de usuário, com foco em consistência de dados e reutilização entre fluxos de criação/edição de usuários e onboarding.

Além do `username`, também foram adicionadas regras centralizadas para `discord_username` e `phone_number`, incluindo validação com `phonenumbers` para telefone.

## Issue relacionada
Closes #35

## Tipo de mudança
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore
- [ ] Docs

## O que foi alterado
- Centralização da lógica de `username` (normalização para lowercase, validação de formato, checagem de disponibilidade e unicidade case-insensitive com `UniqueConstraint(Lower("username"))`).
- Adição de validação/normalização de `discord_username` e `phone_number` em módulo reutilizável, aplicada no model e nos serializers de `users` e `authentication`.
- Validação por `phonenumbers` e inclusão da dependência no projeto.