### PR TITLE
feat(auth): implement group/model-permission strategy for users endpoints

### DIFF
--- a/service/cabulous/settings.py
+++ b/service/cabulous/settings.py
@@ -180,6 +180,9 @@ REST_FRAMEWORK = {
         "rest_framework_simplejwt.authentication.JWTAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",
         "rest_framework.renderers.BrowsableAPIRenderer",

--- a/service/monitoring/views.py
+++ b/service/monitoring/views.py
@@ -1,11 +1,13 @@
 from django.core.cache import cache
 from django.db import connections
 from django.db.utils import OperationalError
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 
 @api_view(["GET"])
+@permission_classes([AllowAny])
 def healthcheck(_request):
     database_ok = True
     redis_ok = True

--- a/service/users/permissions.py
+++ b/service/users/permissions.py
@@ -1,0 +1,29 @@
+from rest_framework.permissions import DjangoModelPermissions
+
+
+class UserModelPermissions(DjangoModelPermissions):
+    perms_map = {
+        "GET": ["%(app_label)s.view_%(model_name)s"],
+        "OPTIONS": [],
+        "HEAD": [],
+        "POST": ["%(app_label)s.add_%(model_name)s"],
+        "PUT": ["%(app_label)s.change_%(model_name)s"],
+        "PATCH": ["%(app_label)s.change_%(model_name)s"],
+        "DELETE": ["%(app_label)s.delete_%(model_name)s"],
+    }
+
+    def has_permission(self, request, view):
+        action = getattr(view, "action", "")
+        if action in {"list", "retrieve"}:
+            return bool(request.user and request.user.is_authenticated)
+        if action in {"update", "partial_update"} and request.user.is_authenticated:
+            return True
+        return super().has_permission(request, view)
+
+    def has_object_permission(self, request, view, obj):
+        action = getattr(view, "action", "")
+        if action in {"update", "partial_update"}:
+            if request.user.has_perm("users.change_user"):
+                return True
+            return obj.pk == request.user.pk
+        return True

--- a/service/users/views.py
+++ b/service/users/views.py
@@ -1,22 +1,11 @@
-from rest_framework.exceptions import PermissionDenied
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
 
 from users.models import User
+from users.permissions import UserModelPermissions
 from users.serializers import UserSerializer
 
 
 class UserViewSet(ModelViewSet):
     queryset = User.objects.all().order_by("username")
     serializer_class = UserSerializer
-    permission_classes = [IsAuthenticated]
-
-    def create(self, request, *args, **kwargs):
-        if not request.user.has_perm("users.add_user"):
-            raise PermissionDenied("You do not have permission to create users.")
-        return super().create(request, *args, **kwargs)
-
-    def perform_destroy(self, instance):
-        if not self.request.user.has_perm("users.delete_user"):
-            raise PermissionDenied("You do not have permission to delete users.")
-        instance.delete()
+    permission_classes = [UserModelPermissions]


### PR DESCRIPTION
## Descrição
Implementado o controle de permissões da API com base no sistema nativo do Django (Groups + Model Permissions), integrado ao DRF.

A configuração global agora utiliza `IsAuthenticated` como padrão para rotas autenticadas, enquanto o gerenciamento de usuários usa permission class específica baseada em `DjangoModelPermissions`, com regra complementar para permitir edição da própria conta por usuário comum.

## Issue relacionada
Closes #36

## Tipo de mudança
- [x] Feature
- [x] Refactor
- [x] Chore
- [ ] Fix
- [ ] Docs

## O que foi alterado
- Definida permission class global padrão no DRF como `IsAuthenticated`.
- Criada permission class customizada para `users` baseada em `DjangoModelPermissions`, mantendo `create/delete` por codename e regra de self-update para usuário comum.
- Atualizado `UserViewSet` para usar a nova permission class e mantido o healthcheck público com `AllowAny`.
