### PR TITLE
feat(auth): enforce onboarding route guard for authenticated users

### DIFF
--- a/service/authentication/permissions.py
+++ b/service/authentication/permissions.py
@@ -1,0 +1,42 @@
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.permissions import BasePermission
+
+ALLOWED_PENDING_ONBOARDING_URL_NAMES = {
+    "auth-login",
+    "auth-refresh",
+    "auth-logout",
+    "auth-me",
+    "auth-onboarding-complete",
+}
+
+
+class IsAuthenticatedWithOnboardingGuard(BasePermission):
+    # DRF uses this default message when has_permission returns False
+    # without raising a custom exception.
+    message = "Authentication credentials were not provided."
+
+    def has_permission(self, request, view):
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+
+        if user.is_superuser:
+            return True
+
+        if getattr(user, "onboarding_completed_at", None) is not None:
+            return True
+
+        if getattr(view, "allow_pending_onboarding", False):
+            return True
+
+        resolver_match = getattr(request, "resolver_match", None)
+        url_name = getattr(resolver_match, "url_name", None)
+        if url_name in ALLOWED_PENDING_ONBOARDING_URL_NAMES:
+            return True
+
+        raise PermissionDenied(
+            detail={
+                "code": "onboarding_required",
+                "detail": "Complete onboarding before accessing this endpoint.",
+            }
+        )

--- a/service/authentication/views.py
+++ b/service/authentication/views.py
@@ -56,7 +56,10 @@ class LogoutView(APIView):
     def post(self, request, *_args, **_kwargs):
         serializer = LogoutSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        try:
+            serializer.save()
+        except TokenError as exc:
+            raise InvalidToken(str(exc))
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/service/authentication/views.py
+++ b/service/authentication/views.py
@@ -62,6 +62,7 @@ class LogoutView(APIView):
 
 class MeView(APIView):
     permission_classes = [IsAuthenticated]
+    allow_pending_onboarding = True
 
     def get(self, request, *_args, **_kwargs):
         serializer = MeSerializer(request.user, context={"request": request})
@@ -70,6 +71,7 @@ class MeView(APIView):
 
 class OnboardingFirstAccessView(APIView):
     permission_classes = [IsAuthenticated]
+    allow_pending_onboarding = True
 
     def post(self, request, *_args, **_kwargs):
         user = request.user

--- a/service/cabulous/settings.py
+++ b/service/cabulous/settings.py
@@ -181,7 +181,7 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.SessionAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.IsAuthenticated",
+        "authentication.permissions.IsAuthenticatedWithOnboardingGuard",
     ],
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",

--- a/service/users/views.py
+++ b/service/users/views.py
@@ -1,5 +1,6 @@
 from rest_framework.viewsets import ModelViewSet
 
+from authentication.permissions import IsAuthenticatedWithOnboardingGuard
 from users.models import User
 from users.permissions import UserModelPermissions
 from users.serializers import UserSerializer
@@ -8,4 +9,4 @@ from users.serializers import UserSerializer
 class UserViewSet(ModelViewSet):
     queryset = User.objects.all().order_by("username")
     serializer_class = UserSerializer
-    permission_classes = [UserModelPermissions]
+    permission_classes = [IsAuthenticatedWithOnboardingGuard, UserModelPermissions]


### PR DESCRIPTION
## Descrição
Implementado bloqueio centralizado no backend para usuários autenticados com onboarding pendente, usando `onboarding_completed_at` como fonte de verdade.

Enquanto o onboarding não é concluído, o acesso fica restrito aos endpoints necessários para completar o fluxo (`login`, `refresh`, `logout`, `/me` e `onboarding/complete`). Após concluir o onboarding, o usuário volta a acessar normalmente as demais rotas autenticadas.

Também foi ajustado o logout para tratar refresh token inválido/blacklisted com erro apropriado (`401`) em vez de `500`.

## Issue relacionada
Closes #37

## Tipo de mudança
- [x] Feature
- [x] Fix
- [x] Refactor
- [ ] Chore
- [ ] Docs

## O que foi alterado
- Criada permission class de guard de onboarding no app `authentication` e configurada como `DEFAULT_PERMISSION_CLASSES` no DRF.
- Liberadas explicitamente as rotas necessárias para onboarding pendente (`login`, `refresh`, `logout`, `/me`, `onboarding/complete`) e aplicado guard também no `UserViewSet`.
- Corrigido `POST /api/auth/logout/` para retornar `401` quando o refresh token estiver inválido ou blacklisted.
