### PR TITLE
feat(users): implement async invite email flow with magic link for first access

### DIFF
--- a/service/communication/tasks.py
+++ b/service/communication/tasks.py
@@ -1,0 +1,237 @@
+from typing import Any
+
+from celery import shared_task
+from pydantic import HttpUrl
+
+from communication.models import DiscordChannelPurpose
+from communication.models.discord_message import (
+    DiscordEmbedAuthor,
+    DiscordEmbedField,
+    DiscordEmbedFooter,
+    DiscordEmbedImage,
+    DiscordEmbedThumbnail,
+)
+from communication.services import DiscordService, EmailService
+
+
+def _parse_http_url(url: HttpUrl | str | None) -> HttpUrl | None:
+    if url is None:
+        return None
+    if isinstance(url, HttpUrl):
+        return url
+    return HttpUrl(url)
+
+
+def _parse_embed_footer(
+    footer: DiscordEmbedFooter | dict[str, Any] | None,
+) -> DiscordEmbedFooter | None:
+    if footer is None:
+        return None
+    if isinstance(footer, DiscordEmbedFooter):
+        return footer
+    return DiscordEmbedFooter.model_validate(footer)
+
+
+def _parse_embed_image(
+    image: DiscordEmbedImage | dict[str, Any] | None,
+) -> DiscordEmbedImage | None:
+    if image is None:
+        return None
+    if isinstance(image, DiscordEmbedImage):
+        return image
+    return DiscordEmbedImage.model_validate(image)
+
+
+def _parse_embed_thumbnail(
+    thumbnail: DiscordEmbedThumbnail | dict[str, Any] | None,
+) -> DiscordEmbedThumbnail | None:
+    if thumbnail is None:
+        return None
+    if isinstance(thumbnail, DiscordEmbedThumbnail):
+        return thumbnail
+    return DiscordEmbedThumbnail.model_validate(thumbnail)
+
+
+def _parse_embed_author(
+    author: DiscordEmbedAuthor | dict[str, Any] | None,
+) -> DiscordEmbedAuthor | None:
+    if author is None:
+        return None
+    if isinstance(author, DiscordEmbedAuthor):
+        return author
+    return DiscordEmbedAuthor.model_validate(author)
+
+
+def _parse_embed_fields(
+    fields: list[DiscordEmbedField | dict[str, Any]] | None,
+) -> list[DiscordEmbedField] | None:
+    if fields is None:
+        return None
+    parsed_fields: list[DiscordEmbedField] = []
+    for field in fields:
+        if isinstance(field, DiscordEmbedField):
+            parsed_fields.append(field)
+        else:
+            parsed_fields.append(DiscordEmbedField.model_validate(field))
+    return parsed_fields
+
+
+@shared_task(name="communication.send_simple_email")
+def send_simple_email_task(
+    *,
+    subject: str,
+    recipients: list[str],
+    body: str,
+    from_email: str | None = None,
+    cc: list[str] | None = None,
+    bcc: list[str] | None = None,
+    reply_to: list[str] | None = None,
+    fail_silently: bool = False,
+) -> int:
+    return EmailService.send_simple_email(
+        subject=subject,
+        recipients=recipients,
+        body=body,
+        from_email=from_email,
+        cc=cc,
+        bcc=bcc,
+        reply_to=reply_to,
+        fail_silently=fail_silently,
+    )
+
+
+@shared_task(name="communication.send_html_template_email")
+def send_html_template_email_task(
+    *,
+    subject: str,
+    recipients: list[str],
+    template_path: str,
+    context: dict[str, Any] | None = None,
+    text_body: str | None = None,
+    from_email: str | None = None,
+    cc: list[str] | None = None,
+    bcc: list[str] | None = None,
+    reply_to: list[str] | None = None,
+    fail_silently: bool = False,
+) -> int:
+    return EmailService.send_html_template_email(
+        subject=subject,
+        recipients=recipients,
+        template_path=template_path,
+        context=context,
+        text_body=text_body,
+        from_email=from_email,
+        cc=cc,
+        bcc=bcc,
+        reply_to=reply_to,
+        fail_silently=fail_silently,
+    )
+
+
+@shared_task(name="communication.send_discord_channel_message")
+def send_discord_channel_message_task(*, webhook_url: str, content: str) -> None:
+    DiscordService.send_channel_message(webhook_url=webhook_url, content=content)
+
+
+@shared_task(name="communication.send_discord_channel_message_by_purpose")
+def send_discord_channel_message_by_purpose_task(
+    *,
+    purpose: DiscordChannelPurpose | str,
+    content: str,
+) -> None:
+    DiscordService.send_channel_message_by_purpose(
+        purpose=purpose,
+        content=content,
+    )
+
+
+@shared_task(name="communication.send_discord_message_from_template")
+def send_discord_channel_message_from_template_task(
+    *,
+    webhook_url: str,
+    template_path: str,
+    context: dict[str, Any] | None = None,
+) -> None:
+    DiscordService.send_channel_message_from_template(
+        webhook_url=webhook_url,
+        template_path=template_path,
+        context=context,
+    )
+
+
+@shared_task(name="communication.send_discord_message_from_template_by_purpose")
+def send_discord_channel_message_from_template_by_purpose_task(
+    *,
+    purpose: DiscordChannelPurpose | str,
+    template_path: str,
+    context: dict[str, Any] | None = None,
+) -> None:
+    DiscordService.send_channel_message_from_template_by_purpose(
+        purpose=purpose,
+        template_path=template_path,
+        context=context,
+    )
+
+
+@shared_task(name="communication.send_discord_embed")
+def send_discord_channel_embed_task(
+    *,
+    webhook_url: str,
+    title: str | None = None,
+    description: str | None = None,
+    color: int | None = None,
+    url: HttpUrl | str | None = None,
+    timestamp: str | None = None,
+    footer: DiscordEmbedFooter | dict[str, Any] | None = None,
+    image: DiscordEmbedImage | dict[str, Any] | None = None,
+    thumbnail: DiscordEmbedThumbnail | dict[str, Any] | None = None,
+    author: DiscordEmbedAuthor | dict[str, Any] | None = None,
+    fields: list[DiscordEmbedField | dict[str, Any]] | None = None,
+    content: str | None = None,
+) -> None:
+    DiscordService.send_channel_embed(
+        webhook_url=webhook_url,
+        title=title,
+        description=description,
+        color=color,
+        url=_parse_http_url(url),
+        timestamp=timestamp,
+        footer=_parse_embed_footer(footer),
+        image=_parse_embed_image(image),
+        thumbnail=_parse_embed_thumbnail(thumbnail),
+        author=_parse_embed_author(author),
+        fields=_parse_embed_fields(fields),
+        content=content,
+    )
+
+
+@shared_task(name="communication.send_discord_embed_by_purpose")
+def send_discord_channel_embed_by_purpose_task(
+    *,
+    purpose: DiscordChannelPurpose | str,
+    title: str | None = None,
+    description: str | None = None,
+    color: int | None = None,
+    url: HttpUrl | str | None = None,
+    timestamp: str | None = None,
+    footer: DiscordEmbedFooter | dict[str, Any] | None = None,
+    image: DiscordEmbedImage | dict[str, Any] | None = None,
+    thumbnail: DiscordEmbedThumbnail | dict[str, Any] | None = None,
+    author: DiscordEmbedAuthor | dict[str, Any] | None = None,
+    fields: list[DiscordEmbedField | dict[str, Any]] | None = None,
+    content: str | None = None,
+) -> None:
+    DiscordService.send_channel_embed_by_purpose(
+        purpose=purpose,
+        title=title,
+        description=description,
+        color=color,
+        url=_parse_http_url(url),
+        timestamp=timestamp,
+        footer=_parse_embed_footer(footer),
+        image=_parse_embed_image(image),
+        thumbnail=_parse_embed_thumbnail(thumbnail),
+        author=_parse_embed_author(author),
+        fields=_parse_embed_fields(fields),
+        content=content,
+    )

--- a/service/users/serializers.py
+++ b/service/users/serializers.py
@@ -1,6 +1,7 @@
 import secrets
 import string
 from datetime import timedelta
+from typing import Any
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils import timezone
@@ -27,9 +28,7 @@ app_settings = get_settings()
 
 
 class UserSerializer(serializers.ModelSerializer):
-    temporary_password = serializers.SerializerMethodField()
-    magic_link = serializers.SerializerMethodField()
-    magic_link_expires_at = serializers.SerializerMethodField()
+    _invite_access_payload: dict[str, Any] | None = None
 
     class Meta:
         model = User
@@ -57,9 +56,6 @@ class UserSerializer(serializers.ModelSerializer):
             "date_joined",
             "created_at",
             "updated_at",
-            "temporary_password",
-            "magic_link",
-            "magic_link_expires_at",
         )
         read_only_fields = (
             "id",
@@ -67,9 +63,6 @@ class UserSerializer(serializers.ModelSerializer):
             "date_joined",
             "created_at",
             "updated_at",
-            "temporary_password",
-            "magic_link",
-            "magic_link_expires_at",
         )
         extra_kwargs = {
             "username": {"validators": []},
@@ -102,7 +95,11 @@ class UserSerializer(serializers.ModelSerializer):
     def validate_username(self, value: str) -> str:
         instance_pk = self.instance.pk if self.instance is not None else None
         try:
-            return clean_username(value, queryset=User.objects.all(), exclude_pk=instance_pk)
+            return clean_username(
+                value,
+                queryset=User.objects.all(),
+                exclude_pk=instance_pk,
+            )
         except DjangoValidationError as exc:
             raise serializers.ValidationError(exc.messages) from exc
 
@@ -148,27 +145,20 @@ class UserSerializer(serializers.ModelSerializer):
         )
 
         frontend_url = app_settings.app_frontend_url.rstrip("/")
-        user._temporary_password = temporary_password  # type: ignore[attr-defined]
-        user._magic_link = f"{frontend_url}/magic-login/{magic_token}"  # type: ignore[attr-defined]
-        user._magic_link_expires_at = expires_at  # type: ignore[attr-defined]
+        magic_link = f"{frontend_url}/magic-login/{magic_token}"
+        self._invite_access_payload = {
+            "temporary_password": temporary_password,
+            "magic_link": magic_link,
+            "magic_link_expires_at": expires_at,
+        }
 
         return user
 
-    def get_temporary_password(self, obj: User) -> str | None:
-        return getattr(obj, "_temporary_password", None)
-
-    def get_magic_link(self, obj: User) -> str | None:
-        return getattr(obj, "_magic_link", None)
-
-    def get_magic_link_expires_at(self, obj: User) -> object | None:
-        return getattr(obj, "_magic_link_expires_at", None)
-
-    def to_representation(self, instance: User) -> dict:
-        data = super().to_representation(instance)
-        for key in ("temporary_password", "magic_link", "magic_link_expires_at"):
-            if data.get(key) is None:
-                data.pop(key, None)
-        return data
+    def get_invite_access_payload(self) -> dict[str, Any] | None:
+        payload = getattr(self, "_invite_access_payload", None)
+        if payload is None:
+            return None
+        return dict(payload)
 
     @staticmethod
     def _generate_temporary_password(length: int = 16) -> str:

--- a/service/users/templates/email/users/invite_access.html
+++ b/service/users/templates/email/users/invite_access.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Convite Cabulous</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f3ff;font-family:Arial,sans-serif;color:#1f1f1f;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" style="max-width:640px;background:#ffffff;border:1px solid #e2dafc;border-radius:12px;padding:24px;">
+          <tr>
+            <td>
+              <h1 style="margin:0 0 16px;font-size:24px;line-height:1.2;color:#2a1f6f;">Convite de acesso ao Cabulous</h1>
+              <p style="margin:0 0 12px;">Olá, {{ user.first_name|default:user.username }}.</p>
+              <p style="margin:0 0 12px;">
+                Você foi convidado para acessar o site da Cabulous.
+              </p>
+              <p style="margin:0 0 16px;">
+                Use o link mágico abaixo para entrar e continuar direto no onboarding:
+              </p>
+              <p style="margin:0 0 16px;">
+                <a href="{{ magic_link }}" style="display:inline-block;padding:12px 16px;background:#3b2db7;color:#ffffff;text-decoration:none;border-radius:8px;">
+                  Acessar Cabulous
+                </a>
+              </p>
+              <p style="margin:0 0 8px;font-size:13px;color:#5f5a7a;">
+                Se preferir, também é possível entrar com a senha temporária:
+                <strong>{{ temporary_password }}</strong>
+              </p>
+              <p style="margin:0 0 16px;font-size:13px;color:#5f5a7a;">
+                Você também pode acessar o site por aqui:
+                <a href="{{ login_url }}">{{ login_url }}</a>
+              </p>
+              <p style="margin:0 0 8px;font-size:13px;color:#5f5a7a;">
+                Link válido até {{ magic_link_expires_at|date:"d/m/Y H:i" }}.
+              </p>
+              <p style="margin:0;font-size:13px;color:#5f5a7a;">
+                Se você não esperava este convite, ignore esta mensagem.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/service/users/templates/email/users/invite_access.html
+++ b/service/users/templates/email/users/invite_access.html
@@ -13,7 +13,7 @@
           <tr>
             <td>
               <h1 style="margin:0 0 16px;font-size:24px;line-height:1.2;color:#2a1f6f;">Convite de acesso ao Cabulous</h1>
-              <p style="margin:0 0 12px;">Olá, {{ user.first_name|default:user.username }}.</p>
+              <p style="margin:0 0 12px;">Olá, {{ invite_display_name }}.</p>
               <p style="margin:0 0 12px;">
                 Você foi convidado para acessar o site da Cabulous.
               </p>
@@ -34,7 +34,7 @@
                 <a href="{{ login_url }}">{{ login_url }}</a>
               </p>
               <p style="margin:0 0 8px;font-size:13px;color:#5f5a7a;">
-                Link válido até {{ magic_link_expires_at|date:"d/m/Y H:i" }}.
+                Link válido até {{ magic_link_expires_at_display }}.
               </p>
               <p style="margin:0;font-size:13px;color:#5f5a7a;">
                 Se você não esperava este convite, ignore esta mensagem.

--- a/service/users/views.py
+++ b/service/users/views.py
@@ -1,11 +1,12 @@
 from typing import Any, cast
 
+from django.utils import timezone
 from rest_framework.serializers import BaseSerializer
 from rest_framework.viewsets import ModelViewSet
 
 from authentication.permissions import IsAuthenticatedWithOnboardingGuard
 from cabulous.config import get_settings
-from communication.services import EmailService
+from communication.tasks import send_html_template_email_task
 from users.models import User
 from users.permissions import UserModelPermissions
 from users.serializers import UserSerializer
@@ -26,15 +27,18 @@ class UserViewSet(ModelViewSet):
         if not user.email or invite_payload is None:
             return
 
+        invite_display_name = user.first_name or user.username
         context: dict[str, Any] = {
-            "user": user,
+            "invite_display_name": invite_display_name,
             "temporary_password": invite_payload["temporary_password"],
             "magic_link": invite_payload["magic_link"],
-            "magic_link_expires_at": invite_payload["magic_link_expires_at"],
+            "magic_link_expires_at_display": timezone.localtime(
+                invite_payload["magic_link_expires_at"]
+            ).strftime("%d/%m/%Y %H:%M"),
             "login_url": f"{app_settings.app_frontend_url.rstrip('/')}/login",
         }
 
-        EmailService.send_html_template_email(
+        send_html_template_email_task.delay(
             subject="Seu convite para acessar o Cabulous",
             recipients=[user.email],
             template_path="email/users/invite_access.html",

--- a/service/users/views.py
+++ b/service/users/views.py
@@ -1,12 +1,42 @@
+from typing import Any, cast
+
+from rest_framework.serializers import BaseSerializer
 from rest_framework.viewsets import ModelViewSet
 
 from authentication.permissions import IsAuthenticatedWithOnboardingGuard
+from cabulous.config import get_settings
+from communication.services import EmailService
 from users.models import User
 from users.permissions import UserModelPermissions
 from users.serializers import UserSerializer
+
+app_settings = get_settings()
 
 
 class UserViewSet(ModelViewSet):
     queryset = User.objects.all().order_by("username")
     serializer_class = UserSerializer
     permission_classes = [IsAuthenticatedWithOnboardingGuard, UserModelPermissions]
+
+    def perform_create(self, serializer: BaseSerializer[Any]) -> None:
+        user_serializer = cast(UserSerializer, serializer)
+        user = user_serializer.save()
+        invite_payload = user_serializer.get_invite_access_payload()
+
+        if not user.email or invite_payload is None:
+            return
+
+        context: dict[str, Any] = {
+            "user": user,
+            "temporary_password": invite_payload["temporary_password"],
+            "magic_link": invite_payload["magic_link"],
+            "magic_link_expires_at": invite_payload["magic_link_expires_at"],
+            "login_url": f"{app_settings.app_frontend_url.rstrip('/')}/login",
+        }
+
+        EmailService.send_html_template_email(
+            subject="Seu convite para acessar o Cabulous",
+            recipients=[user.email],
+            template_path="email/users/invite_access.html",
+            context=context,
+        )


### PR DESCRIPTION
## Descrição
Implementado o fluxo de convite de acesso por email no cadastro de usuários, com envio assíncrono via Celery e uso de link mágico para primeiro acesso.  
A criação de usuário mantém a geração de senha provisória e token mágico internamente, mas esses dados não são mais retornados no payload da API por segurança.  
Também foi adicionada a camada de tasks compartilhadas no app `communication` para envio assíncrono de mensagens de email e Discord.

## Issue relacionada
Closes #38

## Tipo de mudança
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore
- [ ] Docs

## O que foi alterado
- Adicionado envio de convite por email no fluxo de criação de usuário, com template HTML dedicado e conteúdo de acesso inicial.
- Implementado disparo assíncrono com Celery (`shared_task`) para envio de email (incluindo template) e também wrappers assíncronos para envios de Discord.
- Ajustado o serializer de usuários para não expor senha provisória e link mágico na resposta da API, mantendo esses dados apenas para o fluxo interno de convite.