### PR TITLE
feat(authentication): implement password recovery and reset flow

### DIFF
--- a/service/authentication/serializers.py
+++ b/service/authentication/serializers.py
@@ -1,14 +1,25 @@
+import secrets
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, cast
 
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.password_validation import validate_password
+from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils import timezone
+from django.utils.encoding import force_bytes, force_str
+from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
 
+from cabulous.config import get_settings
+from communication.tasks import (
+    send_discord_channel_message_by_purpose_task,
+    send_html_template_email_task,
+)
+from users.models import UserMagicLinkToken
 from users.validators import (
     clean_discord_username,
     clean_phone_number,
@@ -16,10 +27,13 @@ from users.validators import (
     normalize_username,
 )
 
-User = get_user_model()
-
 if TYPE_CHECKING:
     from users.models import User as UserType
+
+    User = UserType
+else:
+    User = get_user_model()
+app_settings = get_settings()
 
 
 class LoginSerializer(serializers.Serializer):
@@ -84,6 +98,116 @@ class RefreshTokenSerializer(TokenRefreshSerializer):
     pass
 
 
+class ForgotAccessSerializer(serializers.Serializer):
+    identifier = serializers.CharField(trim_whitespace=True)
+
+    def save(self, **kwargs: Any) -> dict[str, Any]:
+        validated_data = cast(dict[str, Any], self.validated_data)
+        identifier = validated_data["identifier"]
+
+        user = User.objects.filter(username=normalize_username(identifier)).first()
+        if user is None:
+            user = User.objects.filter(email__iexact=identifier).first()
+
+        if user is None or not user.is_active:
+            return {}
+
+        frontend_url = app_settings.app_frontend_url.rstrip("/")
+        display_name = user.first_name or user.username
+
+        if user.onboarding_completed_at is None:
+            magic_token = secrets.token_urlsafe(48)
+            expires_at = timezone.now() + timedelta(hours=72)
+            UserMagicLinkToken.objects.create(
+                user=user,
+                token=magic_token,
+                expires_at=expires_at,
+                created_by=None,
+            )
+            onboarding_link = f"{frontend_url}/magic-login/{magic_token}"
+            onboarding_context = {
+                "display_name": display_name,
+                "magic_link": onboarding_link,
+                "magic_link_expires_at_display": timezone.localtime(expires_at).strftime(
+                    "%d/%m/%Y %H:%M"
+                ),
+            }
+            if user.email:
+                send_html_template_email_task.delay(
+                    subject="Recuperacao de acesso - Cabulous",
+                    recipients=[user.email],
+                    template_path="email/authentication/recover_pending_onboarding.html",
+                    context=onboarding_context,
+                )
+            if user.discord_username:
+                send_discord_channel_message_by_purpose_task.delay(
+                    purpose="BOARD_UPDATES",
+                    content=(
+                        f"{user.discord_username}, voce possui onboarding pendente no Cabulous. "
+                        f"Use este link para concluir o primeiro acesso: {onboarding_link}"
+                    ),
+                )
+            return {}
+
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+        token = default_token_generator.make_token(user)
+        reset_link = f"{frontend_url}/reset-password?uid={uid}&token={token}"
+        reset_context = {
+            "display_name": display_name,
+            "reset_link": reset_link,
+        }
+        if user.email:
+            send_html_template_email_task.delay(
+                subject="Redefinicao de senha - Cabulous",
+                recipients=[user.email],
+                template_path="email/authentication/password_reset_request.html",
+                context=reset_context,
+            )
+        if user.discord_username:
+            send_discord_channel_message_by_purpose_task.delay(
+                purpose="BOARD_UPDATES",
+                content=(
+                    f"{user.discord_username}, recebemos uma solicitacao de redefinicao de senha "
+                    f"para sua conta Cabulous. Use este link: {reset_link}"
+                ),
+            )
+        return {}
+
+
+class PasswordResetConfirmSerializer(serializers.Serializer):
+    uid = serializers.CharField()
+    token = serializers.CharField()
+    new_password = serializers.CharField(write_only=True, trim_whitespace=False)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        uid = attrs["uid"]
+        token = attrs["token"]
+        new_password = attrs["new_password"]
+
+        try:
+            user_id = force_str(urlsafe_base64_decode(uid))
+            user = User.objects.get(pk=user_id)
+        except (TypeError, ValueError, OverflowError, User.DoesNotExist) as exc:
+            raise serializers.ValidationError({"token": "Invalid reset token."}) from exc
+
+        if not default_token_generator.check_token(user, token):
+            raise serializers.ValidationError({"token": "Invalid or expired reset token."})
+
+        validate_password(new_password, user=user)
+        attrs["user"] = user
+        return attrs
+
+    def save(self, **kwargs: Any) -> dict[str, Any]:
+        validated_data = cast(dict[str, Any], self.validated_data)
+        user = validated_data["user"]
+        new_password = validated_data["new_password"]
+
+        user.set_password(new_password)
+        user.password_defined_at = timezone.now()
+        user.save()
+        return {}
+
+
 class OnboardingFirstAccessSerializer(serializers.ModelSerializer):
     new_password = serializers.CharField(write_only=True, trim_whitespace=False)
 
@@ -100,7 +224,7 @@ class OnboardingFirstAccessSerializer(serializers.ModelSerializer):
             "avatar",
             "bio",
         )
-        extra_kwargs = {
+        extra_kwargs: dict[str, dict[str, Any]] = {
             "username": {"validators": []},
         }
 

--- a/service/authentication/templates/email/authentication/password_reset_request.html
+++ b/service/authentication/templates/email/authentication/password_reset_request.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Redefinição de senha</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f3ff;font-family:Arial,sans-serif;color:#1f1f1f;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" style="max-width:640px;background:#ffffff;border:1px solid #e2dafc;border-radius:12px;padding:24px;">
+          <tr>
+            <td>
+              <h1 style="margin:0 0 16px;font-size:24px;line-height:1.2;color:#2a1f6f;">Redefinição de senha</h1>
+              <p style="margin:0 0 12px;">Olá, {{ display_name }}.</p>
+              <p style="margin:0 0 16px;">
+                Recebemos uma solicitação para redefinir sua senha de acesso ao Cabulous.
+              </p>
+              <p style="margin:0 0 16px;">
+                <a href="{{ reset_link }}" style="display:inline-block;padding:12px 16px;background:#3b2db7;color:#ffffff;text-decoration:none;border-radius:8px;">
+                  Redefinir senha
+                </a>
+              </p>
+              <p style="margin:0;font-size:13px;color:#5f5a7a;">
+                Se você não solicitou esta redefinição, ignore esta mensagem.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/service/authentication/templates/email/authentication/recover_pending_onboarding.html
+++ b/service/authentication/templates/email/authentication/recover_pending_onboarding.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Retomar primeiro acesso</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f3ff;font-family:Arial,sans-serif;color:#1f1f1f;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" style="max-width:640px;background:#ffffff;border:1px solid #e2dafc;border-radius:12px;padding:24px;">
+          <tr>
+            <td>
+              <h1 style="margin:0 0 16px;font-size:24px;line-height:1.2;color:#2a1f6f;">Retomar primeiro acesso</h1>
+              <p style="margin:0 0 12px;">Olá, {{ display_name }}.</p>
+              <p style="margin:0 0 16px;">
+                Sua conta Cabulous ainda está com onboarding pendente.
+              </p>
+              <p style="margin:0 0 16px;">
+                Use o link abaixo para continuar seu primeiro acesso:
+              </p>
+              <p style="margin:0 0 16px;">
+                <a href="{{ magic_link }}" style="display:inline-block;padding:12px 16px;background:#3b2db7;color:#ffffff;text-decoration:none;border-radius:8px;">
+                  Continuar onboarding
+                </a>
+              </p>
+              <p style="margin:0 0 8px;font-size:13px;color:#5f5a7a;">
+                Link válido até {{ magic_link_expires_at_display }}.
+              </p>
+              <p style="margin:0;font-size:13px;color:#5f5a7a;">
+                Se você não solicitou esta recuperação, ignore esta mensagem.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/service/authentication/urls.py
+++ b/service/authentication/urls.py
@@ -1,10 +1,12 @@
 from django.urls import path
 
 from authentication.views import (
+    ForgotAccessView,
     LoginView,
     LogoutView,
     MeView,
     OnboardingFirstAccessView,
+    PasswordResetConfirmView,
     RefreshView,
 )
 
@@ -13,6 +15,12 @@ urlpatterns = [
     path("refresh/", RefreshView.as_view(), name="auth-refresh"),
     path("logout/", LogoutView.as_view(), name="auth-logout"),
     path("me/", MeView.as_view(), name="auth-me"),
+    path("forgot-password/", ForgotAccessView.as_view(), name="auth-forgot-password"),
+    path(
+        "reset-password/confirm/",
+        PasswordResetConfirmView.as_view(),
+        name="auth-reset-password-confirm",
+    ),
     path(
         "onboarding/complete/",
         OnboardingFirstAccessView.as_view(),

--- a/service/authentication/views.py
+++ b/service/authentication/views.py
@@ -8,10 +8,12 @@ from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 from rest_framework_simplejwt.tokens import RefreshToken
 
 from authentication.serializers import (
+    ForgotAccessSerializer,
     LoginSerializer,
     LogoutSerializer,
     MeSerializer,
     OnboardingFirstAccessSerializer,
+    PasswordResetConfirmSerializer,
     RefreshTokenSerializer,
 )
 
@@ -70,6 +72,37 @@ class MeView(APIView):
     def get(self, request: Any, *_args: Any, **_kwargs: Any) -> Response:
         serializer = MeSerializer(request.user, context={"request": request})
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class ForgotAccessView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request: Any, *_args: Any, **_kwargs: Any) -> Response:
+        serializer = ForgotAccessSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(
+            {
+                "detail": (
+                    "If an account exists for the provided identifier, "
+                    "recovery instructions were sent."
+                )
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+class PasswordResetConfirmView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request: Any, *_args: Any, **_kwargs: Any) -> Response:
+        serializer = PasswordResetConfirmSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(
+            {"detail": "Password reset completed successfully."},
+            status=status.HTTP_200_OK,
+        )
 
 
 class OnboardingFirstAccessView(APIView):


### PR DESCRIPTION
## Descrição
Implementado o fluxo completo de recuperação de acesso com suporte a `email` ou `username`, usando `PasswordResetTokenGenerator` (padrão Django) para redefinição de senha.  
Quando o usuário ainda não concluiu onboarding, o fluxo envia link mágico de primeiro acesso; quando já concluiu, envia link de reset de senha.  
Também foram adicionados os endpoints e templates de email para ambos os cenários, mantendo resposta neutra no endpoint de recuperação para não expor existência de conta.

## Issue relacionada
Closes #56

## Tipo de mudança
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore
- [ ] Docs

## O que foi alterado
- Criados endpoints `POST /api/auth/forgot-password/` e `POST /api/auth/reset-password/confirm/` no app `authentication`.
- Implementada lógica condicional de recuperação: onboarding pendente → link mágico; onboarding concluído → link de redefinição com token padrão Django.
- Adicionados templates HTML de email para recuperação de senha e retomada de onboarding, com envio assíncrono via tasks de comunicação.