### PR TITLE
docs(service): add backend module agent guidance

### DIFF
--- a/service/AGENTS.md
+++ b/service/AGENTS.md
@@ -1,0 +1,32 @@
+# Backend service guidance
+
+These rules apply to every package under `service/`. Individual app docs (`service/*/AGENTS.md`) inherit from this file and should only add app-specific boundaries or commands.
+
+## Django app structure
+
+- Every first-party package under `service/` is a Django app; its `apps.py` declares the app name.
+- Keep domain logic close to `models.py`; use `services/` only for external/connector behavior; keep `tasks.py` minimal wrappers.
+- Identifiers and user-facing strings in this project are already in Portuguese; preserve existing vocabulary when changing behavior.
+- `service/common` is shared infrastructure (`BaseModel`, soft delete, storage backends). Avoid creating another shared app without a shared reason.
+
+## Local commands
+
+- Backend targets are routed through the repo root: `make service <target>`, `make service manage cmd='<command>'`.
+- Examples:
+  - `make service makemigrations`
+  - `make service makemigrations-dev`
+  - `make service manage cmd='makemigrations analytics users'`
+  - `make service test`
+  - `make service manage cmd='check'`
+
+## Migration policy
+
+Migrations are part of the codebase and require the same review rigor as models or tests.
+
+- Models are the source of truth for structural schema.
+- Normally generate structural migrations with `make makemigrations` or `make service manage cmd='makemigrations <app> ...'` when selecting specific apps or flags.
+- If migrations and models diverge, fix the mismatch in code; don't hand-write structural operations to hide drift.
+- Commit generated migrations with the matching model change; the developer and reviewer must be able to explain every operation in the new migration file.
+- Require `make service manage cmd='makemigrations --check --dry-run --noinput'` to report `No changes detected` before merging a model change.
+- Hand-edit or add migration code only for explicit exceptional operations such as data preservation (`RunPython`/reverse) or a proven operation-order requirement.
+- Never rewrite deployed migrations. If a deployed migration needs correction, add a new incremental migration that safely moves the schema forward.

--- a/service/analytics/AGENTS.md
+++ b/service/analytics/AGENTS.md
@@ -1,0 +1,25 @@
+# Backend module: `analytics`
+
+## Purpose
+
+Party statistics and derived analytics state. Owns aggregate domain models and admin exploration for analytics data.
+
+## Owned code
+
+- Models: `service/analytics/models.py`
+- Admin: `service/analytics/admin.py`
+
+## Boundaries
+
+- Currently limited to aggregate statistics linked to `users.User`.
+- Does not own raw user behavior sources; those belong in `events` or other domain apps.
+
+## Validation commands
+
+- `make service manage cmd='check'`
+- `make service test`
+- `make service manage cmd='makemigrations --check --dry-run --noinput'`
+
+## Local conventions
+
+- Derived fields in `PartyStatistics.save()` are preserved; avoid splitting them into separate compute flows without a migration plan.

--- a/service/authentication/AGENTS.md
+++ b/service/authentication/AGENTS.md
@@ -1,0 +1,29 @@
+# Backend module: `authentication`
+
+## Purpose
+
+Auth boundary. Owns login/logout/refresh flows, onboarding first-access enforcement, password-reset handling, and periodic JWT cleanup.
+
+## Owned code
+
+- Models: `service/authentication/models.py`
+- Views: `service/authentication/views.py`
+- URLs: `service/authentication/urls.py`
+- Admin/tasks: `service/authentication/admin.py`, `service/authentication/tasks.py`
+
+## Boundaries
+
+- Owns `authentication.*` endpoints under `/api/auth/`.
+- Depends on `users.User` as the auth identity model; do not duplicate user state here.
+- Reuses `communication` for email delivery and `monitoring` for health behavior when needed.
+
+## Validation commands
+
+- `make service manage cmd='check'`
+- `make service test`
+- `make service manage cmd='makemigrations --check --dry-run --noinput'`
+
+## Local conventions
+
+- Auth behavior flows through tasks/configurable Celery beat jobs declared in `service/cabulous/settings.py`.
+- Changes to auth requirements should land as model or serializer-level rules, plus tests under `service/authentication/tests/`.

--- a/service/cabulous/AGENTS.md
+++ b/service/cabulous/AGENTS.md
@@ -1,0 +1,29 @@
+# Backend module: `cabulous`
+
+## Purpose
+
+Top-level Django project package. Owns settings, URL routing, ASGI/WSGI entrypoints, Celery app wiring, and environment configuration for every backend service.
+
+## Owned code
+
+- Configuration: `service/cabulous/config.py`
+- Settings: `service/cabulous/settings.py`
+- App/process entrypoints: `service/cabulous/asgi.py`, `service/cabulous/wsgi.py`, `service/cabulous/celery.py`
+- Root backend URL map: `service/cabulous/urls.py`
+
+## Boundaries
+
+- Does not define business-domain models or per-feature views.
+- First-party domain logic lives under `service/<app>/`; shared abstractions live in `service/common`.
+- Frontend code stays under `app/web/`.
+
+## Validation commands
+
+- `make service manage cmd='check'`
+- `make service manage cmd='makemigrations --check --dry-run --noinput'`
+
+## Local conventions
+
+- First-party apps are registered in `INSTALLED_APPS` inside `service/cabulous/settings.py`; add new apps there.
+- External integrations and secrets flow through `service/cabulous/config.py`; do not hardcode values in app code.
+- See `service/AGENTS.md` for shared backend workflow, especially the migration policy.

--- a/service/common/AGENTS.md
+++ b/service/common/AGENTS.md
@@ -1,0 +1,26 @@
+# Backend module: `common`
+
+## Purpose
+
+Shared Django foundation for every service app.
+
+## Owned code
+
+- Base abstractions: `service/common/models/abstracts.py`
+- Shared storage/model helpers as present in `service/common/`
+
+## Boundaries
+
+- Provides cross-cutting base classes such as base models and soft-delete behavior.
+- Should not contain business-specific models, views, or task flows.
+- Other apps depend on `common`; changes here can affect migrations or behavior everywhere.
+
+## Validation commands
+
+- `make service manage cmd='check'`
+- `make service manage cmd='makemigrations --check --dry-run --noinput'`
+
+## Local conventions
+
+- Treat `common` as stable infrastructure: prefer addition of abstract helpers over changing existing abstract class names or behavior.
+- Model or migration changes here should be reviewed across all dependent apps.

--- a/service/communication/AGENTS.md
+++ b/service/communication/AGENTS.md
@@ -1,0 +1,27 @@
+# Backend module: `communication`
+
+## Purpose
+
+Outbound messaging boundary. Owns email delivery and Discord webhook/messaging behavior.
+
+## Owned code
+
+- Models/helpers: `service/communication/models/`, `service/communication/helpers/`
+- Service layer: `service/communication/services/`
+- Tasks/URLs/admin: `service/communication/tasks.py`, `service/communication/urls.py`, `service/communication/admin.py`
+
+## Boundaries
+
+- Should remain a thin transport layer; business rules about when/why to notify belong in the domain app.
+- Keeps message template/payload contracts; do not leak raw webhook secrets into model state unnecessarily.
+
+## Validation commands
+
+- `make service manage cmd='check'`
+- `make service test`
+- `make service manage cmd='makemigrations --check --dry-run --noinput'`
+
+## Local conventions
+
+- Prefer Celery tasks for outbound side effects; keep view-level code readable and non-blocking.
+- Template rendering and payload validation already live under `service/communication/services/`.

--- a/service/events/AGENTS.md
+++ b/service/events/AGENTS.md
@@ -1,0 +1,27 @@
+# Backend module: `events`
+
+## Purpose
+
+Event domain. Owns events, audiences, participants, locations, event photos, and related enum/color metadata.
+
+## Owned code
+
+- Domain modules: `service/events/enums.py`, `service/events/constants.py`, `service/events/models.py`
+- Web/admin/tests: `service/events/views.py`, `service/events/admin.py`, `service/events/tests/`
+
+## Boundaries
+
+- References `users.User` for creators/participants and `media.Photo` for event photos.
+- Soft delete is enforced through custom managers in `Event`; use explicit managers instead of raw querysets.
+- Historical migrations exist under `service/events/migrations/`; do not rewrite them.
+
+## Validation commands
+
+- `make service manage cmd='check'`
+- `make service test`
+- `make service manage cmd='makemigrations --check --dry-run --noinput'`
+
+## Local conventions
+
+- Status-related fields (`end_at`, `status`, `cancelled_at`) are derived/validated in model methods/clean; keep business meaning inside the models layer.
+- See `service/AGENTS.md` for migration policy: prefer new incremental migrations after deployment.

--- a/service/integrations/AGENTS.md
+++ b/service/integrations/AGENTS.md
@@ -1,0 +1,24 @@
+# Backend module: `integrations`
+
+## Purpose
+
+External integration surface. Owns webhook entrypoints and inbound external data flows.
+
+## Owned code
+
+- Views/admin/urls: `service/integrations/views.py`, `service/integrations/admin.py`, `service/integrations/urls.py`
+
+## Boundaries
+
+- Currently represented by placeholder GitHub webhook handling; expand carefully around webhook resilience and idempotency.
+- Should hand off domain-specific processing instead of embedding business rules deeply.
+
+## Validation commands
+
+- `make service manage cmd='check'`
+- `make service test`
+- `make service manage cmd='makemigrations --check --dry-run --noinput'`
+
+## Local conventions
+
+- Webhook endpoints are externally reachable; keep security validation explicit and close to the view layer.

--- a/service/media/AGENTS.md
+++ b/service/media/AGENTS.md
@@ -1,0 +1,25 @@
+# Backend module: `media`
+
+## Purpose
+
+Global media registry. Owns shared photo metadata and storage identity for later association with domain objects.
+
+## Owned code
+
+- Models: `service/media/models.py`
+- Tests: `service/media/tests/test_models.py`
+
+## Boundaries
+
+- Represents uploaded object metadata only; actual file/blob lifecycle interacts with `common.storage_backends` and MinIO/S3 settings.
+- Other apps should associate with `media.Photo`; avoid duplicating object/size/content-type metadata elsewhere.
+
+## Validation commands
+
+- `make service manage cmd='check'`
+- `make service test`
+- `make service manage cmd='makemigrations --check --dry-run --noinput'`
+
+## Local conventions
+
+- Media metadata changes should preserve deterministic ordering/indexing for `taken_on` and `created_at` lookups where possible.

--- a/service/monitoring/AGENTS.md
+++ b/service/monitoring/AGENTS.md
@@ -1,0 +1,25 @@
+# Backend module: `monitoring`
+
+## Purpose
+
+System health surface. Owns lightweight health/status endpoints and simple Celery-driven liveness behavior.
+
+## Owned code
+
+- Health view: `service/monitoring/views.py`
+- URLs/admin/tasks: `service/monitoring/urls.py`, `service/monitoring/admin.py`, `service/monitoring/tasks.py`
+
+## Boundaries
+
+- Should stay intentionally cheap; avoid adding business state or blocking dependencies to health checks.
+- Models are currently placeholder-only; if a model is added, it should belong in a more specific app unless it is truly cross-cutting infra.
+
+## Validation commands
+
+- `make service manage cmd='check'`
+- `make service test`
+- `make service manage cmd='makemigrations --check --dry-run --noinput'`
+
+## Local conventions
+
+- Health checks are part of deployment reliability; keep contract changes explicit and minimal.

--- a/service/users/AGENTS.md
+++ b/service/users/AGENTS.md
@@ -1,0 +1,29 @@
+# Backend module: `users`
+
+## Purpose
+
+Profile and identity surface. Owns the custom `User` model, magic-link authentication artifacts, profile data, media upload signing, and user-facing API behavior.
+
+## Owned code
+
+- Models: `service/users/models.py`
+- Views/serializers: `service/users/views.py`, `service/users/serializers.py`
+- Upload helpers: `service/users/services/upload_signing.py`
+- URLs/tasks/admin: `service/users/urls.py`, `service/users/tasks.py`, `service/users/admin.py`
+
+## Boundaries
+
+- `AUTH_USER_MODEL` is `users.User`; auth-dependent behavior in other apps should treat this as the source of truth for identity.
+- Actual media storage is owned by `media`; `users` defines upload keys and signed-url generation only.
+- Handles onboarding state, soft-delete behavior, and cleanup of auth tokens.
+
+## Validation commands
+
+- `make service manage cmd='check'`
+- `make service test`
+- `make service manage cmd='makemigrations --check --dry-run --noinput'`
+
+## Local conventions
+
+- Sensitive filename/state derivation helpers live in `service/users/models.py`.
+- Signed upload behavior should be tested via service-level cases; avoid exposing MinIO internals across packages.


### PR DESCRIPTION
## Summary
- Adds a shared `service/AGENTS.md` and module-level guidance for the backend packages.
- Documents backend ownership, validation commands, and boundaries.
- Establishes the migration policy: models are the structural source of truth; normally generate migrations via the Makefile; reserve manual migration code for data-preservation/reversal or proven ordering exceptions.

## Validation
- `git diff --check`

## Integration
- This PR targets `pipeline/cabulous-events-api`, not `develop`, so it contains only the documentation commit and does not bypass the in-progress Events delivery branch.
- It can be merged after the active T2 writer/reviewer releases the shared delivery worktree.